### PR TITLE
Enhance Metamask account switching

### DIFF
--- a/packages/w3wallets/CHANGELOG.md
+++ b/packages/w3wallets/CHANGELOG.md
@@ -1,5 +1,29 @@
 # w3wallets
 
+## 0.7.0
+
+### Minor Changes
+
+- Improve MetaMask switch account API and fix Backpack
+
+## 0.9.0
+
+### Minor Changes
+
+- Improve MetaMask switch account API and fix Backpack
+
+## 0.8.0
+
+### Minor Changes
+
+- Improve MetaMask switch account API and fix Backpack
+
+## 0.7.0
+
+### Minor Changes
+
+- Improve MetaMask switch account API and fix Backpack
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/w3wallets/package.json
+++ b/packages/w3wallets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "w3wallets",
   "description": "browser wallets for playwright",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Maksandre/w3wallets",

--- a/packages/w3wallets/src/backpack/backpack.ts
+++ b/packages/w3wallets/src/backpack/backpack.ts
@@ -106,5 +106,8 @@ export class Backpack extends Wallet {
       await expect(this.page.getByText("You're all good!")).toBeVisible();
     }
     await this.page.goto(`chrome-extension://${this.extensionId}/popup.html`);
+    await this.page
+      .getByTestId("AccountBalanceRoundedIcon")
+      .waitFor({ state: "visible" });
   }
 }

--- a/packages/w3wallets/tests/metamask.spec.ts
+++ b/packages/w3wallets/tests/metamask.spec.ts
@@ -5,7 +5,7 @@ import { sleep } from "./utils/sleep";
 
 const test = withWallets(base, "metamask");
 
-test.beforeEach(async ({metamask}) => {
+test.beforeEach(async ({ metamask }) => {
   await metamask.onboard(config.ethMnemonic);
 
   // TODO: to close solana promo popup
@@ -46,7 +46,26 @@ test("Can import account and switch between accounts", async ({ metamask }) => {
   const currentAccount2 = await getAccountName();
   expect(currentAccount2).not.toEqual(currentAccount1);
 
-  await metamask.switchAccount("Account 1");
+  await metamask.switchAccount({ name: "Account 1" });
   const currentAccount3 = await getAccountName();
   expect(currentAccount3).toEqual("Account 1");
+});
+
+test("Can add a custom network and switch account", async ({ metamask }) => {
+  await metamask.connectToNetwork({
+    chainId: 123420001114,
+    currencySymbol: "CAMP",
+    name: "Basecamp",
+    rpc: "https://rpc-campnetwork.xyz",
+  });
+
+  await metamask.importAccount(config.ethPrivateKeys[1]);
+  await metamask.switchAccount({ name: "Account 1" });
+});
+
+test("Can switch account by address", async ({ metamask }) => {
+  await metamask.importAccount(config.ethPrivateKeys[1]);
+  await metamask.switchAccount({
+    address: "0x5b7BDE2eF040354Ba49d9c30e492c91391B5b353",
+  });
 });

--- a/packages/w3wallets/tests/utils/address.ts
+++ b/packages/w3wallets/tests/utils/address.ts
@@ -1,0 +1,3 @@
+export const shortenAddress = (address: string) => {
+  return `${address.slice(0, 7)}...${address.slice(-5)}`;
+};


### PR DESCRIPTION
- Updated `switchAccount` method to accept both account names and addresses.
- Added `shortenAddress` utility function for better address display.
- Improved tests to cover switching accounts by both name and address.
- Added a test for connecting to a custom network.