### PR TITLE
Fix MetaMask selectors for importAccount and enableTestNetworks

### DIFF
--- a/packages/w3wallets/package.json
+++ b/packages/w3wallets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "w3wallets",
   "description": "browser wallets for playwright",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Maksandre/w3wallets",

--- a/packages/w3wallets/src/wallets/metamask/metamask.ts
+++ b/packages/w3wallets/src/wallets/metamask/metamask.ts
@@ -568,17 +568,27 @@ export class Metamask extends Wallet {
     );
     await expect(toggle).toBeVisible({ timeout: config.expectTimeout });
     await toggle.click();
-    await this.page.keyboard.press("Escape");
+    // The Networks panel is now a route (#/networks?drawerOpen=true) that
+    // does not close on Escape. Navigate back to home so subsequent
+    // home-page selectors (e.g. sort-by-networks) become actionable.
+    await this.page.goto(`chrome-extension://${this.extensionId}/home.html`);
   }
 
   async importAccount(privateKey: string) {
     debug("metamask.importAccount: starting");
     await this.page.getByTestId("account-menu-icon").click();
     await this.page.getByTestId("account-list-add-wallet-button").click();
-    await this.page.getByTestId("add-wallet-modal-import-account").click();
+    await this.page.getByTestId("choose-wallet-type-import-account").click();
     await this.page.locator("#private-key-box").fill(privateKey);
     await this.page.getByTestId("import-account-confirm-button").click();
-    await this.page.getByRole("button", { name: "Back" }).click();
+    // After confirm, MetaMask lands on the wallet-type chooser. Step back
+    // to the account list, then click the new imported account cell
+    // (keyring-prefixed testid) to select it and return to home.
+    await this.page.getByTestId("back-button").click();
+    await this.page
+      .locator('[data-testid^="multichain-account-cell-keyring:"]')
+      .first()
+      .click();
   }
 
   async accountNameIs(accountName: string) {


### PR DESCRIPTION
MetaMask 13.x replaced the "Add a wallet" modal with a routed chooser and turned the Networks panel into a routed drawer that no longer closes on Escape. Update importAccount() to use the new choose-wallet-type-import-account testid, navigate back to the account list after confirm, and click the keyring-prefixed account cell to select+return-to-home. Update enableTestNetworks() to navigate to home.html instead of pressing Escape so the next home-page selector (sort-by-networks) is actionable.